### PR TITLE
Contrast difference between two images

### DIFF
--- a/skimage_contrib/color/__init__.py
+++ b/skimage_contrib/color/__init__.py
@@ -1,0 +1,3 @@
+from color_metrics import contrast_difference
+
+__all__ = ["contrast_difference"]

--- a/skimage_contrib/color/color_metrics.py
+++ b/skimage_contrib/color/color_metrics.py
@@ -1,0 +1,113 @@
+"""
+Functions for calculating the utility of color normalisation.
+
+Current implementation provides function for:
+1. contrast difference calculation
+
+References:
+    .. [1] Mukherjee, J., & Mitra, S. K. (2008). Enhancement of
+           color images by scaling the DCT coefficients. IEEE
+           Transactions on Image processing, 17(10), 1783-1794.
+           :DOI:10.1109/TIP.2008.2002826
+    .. [2] Pontalba JT, Gwynne-Timothy T, David E, Jakate K,
+           Androutsos D and Khademi A (2019) Assessing the
+           Impact of Color Normalization in Convolutional
+           Neural Network-Based Nuclei Segmentation Frameworks.
+           Front. Bioeng. Biotechnol. 7:300.
+           :DOI:10.3389/fbioe.2019.00300
+"""
+
+import numpy as np
+from skimage.color import rgb2gray, rgba2rgb
+from skimage.util import view_as_blocks
+from skimage._shared.utils import check_shape_equality
+
+def contrast_difference(image_true, image_test, window=None,
+                        multichannel=False):
+    """Determine the contrast difference between two images.
+
+    Parameters
+    ----------
+    image_true : array-like
+        Unnormalised image, in grayscale, RGB or RGBA.
+    image_test : array-like
+        Normalised image, in grayscale, RGB or RGBA.
+    window : tuple, optional
+        Window size to compute the contrast difference. Must divide image
+        exactly without any padding. Defaults to the entire image size.
+    multichannel : bool
+        Whether the last axis of the image is to be interpreted as multiple
+        channels or another spatial dimension.
+
+    Returns
+    -------
+    out : float
+        Contrast difference between the test and true images.
+        Positive contrast difference indicates test image has higher
+        contrast than true image
+
+    References
+    ----------
+    .. [1] Mukherjee, J., & Mitra, S. K. (2008). Enhancement of
+           color images by scaling the DCT coefficients. IEEE
+           Transactions on Image processing, 17(10), 1783-1794.
+           :DOI:10.1109/TIP.2008.2002826
+    .. [2] Pontalba JT, Gwynne-Timothy T, David E, Jakate K,
+           Androutsos D and Khademi A (2019) Assessing the
+           Impact of Color Normalization in Convolutional
+           Neural Network-Based Nuclei Segmentation Frameworks.
+           Front. Bioeng. Biotechnol. 7:300.
+           :DOI:10.3389/fbioe.2019.00300
+
+    Examples
+    --------
+    >>> from skimage import data
+    >>> from skimage.exposure import adjust_gamma
+    >>> image = data.astronaut()
+    >>> adjusted_1 = adjust_gamma(image, 2)
+    >>> contrast_difference(image, adjusted_1, multichannel=True)
+    0.20741130646841788
+    >>> adjusted_2 = adjust_gamma(image, 0.5)
+    >>> contrast_difference(image, adjusted_2, multichannel=True)
+    -0.14646830821582324
+    """
+
+    check_shape_equality(image_true, image_test)
+
+    images = [image_test, image_true]
+    contrasts = []
+
+    for image in images:
+        image = np.asanyarray(image)
+
+        if multichannel:
+            if image.shape[-1] not in (3, 4):
+                    msg = ("The last axis of the input image is interpreted as "
+                           "channels. Input image with shape {0} has {1} "
+                           "channels in last axis. ``contrast_difference`` is "
+                           "implemented for RGB and RGBA images only (if "
+                           "mutichannel is true).")
+                    raise ValueError(msg.format(image.shape, image.shape[-1]))
+
+            if image.shape[-1] == 4:
+                image = rgba2rgb(image)
+            if image.shape[-1] == 3:
+                image = rgb2gray(image)
+
+        if window is None:
+            window = image.shape
+
+        windows = view_as_blocks(image, window)
+        new_shape = windows.shape[:(-len(window))] + (-1,)
+        flat_windows = windows.reshape(new_shape)
+
+        mean_windows = np.mean(flat_windows, axis=-1)
+        std_windows = np.std(flat_windows, axis=-1)
+
+        epsilon = np.finfo(mean_windows.dtype).eps
+        mean_windows = np.where(mean_windows==0, epsilon, mean_windows)
+        contrast = std_windows / mean_windows
+
+        contrasts.append(np.mean(contrast))
+
+    return contrasts[0] - contrasts[1]

--- a/skimage_contrib/color/tests/test_color_contrast.py
+++ b/skimage_contrib/color/tests/test_color_contrast.py
@@ -1,0 +1,73 @@
+from skimage._shared.testing import assert_equal, assert_almost_equal
+from skimage._shared import testing
+from skimage.color import rgb2gray, rgba2rgb
+import numpy as np
+
+from skimage_contrib.color import contrast_difference
+
+def test_contrast_difference_errors():
+
+    x = np.ones((10,10))
+    # shape mismatch
+    with testing.raises(ValueError):
+        contrast_difference(x[:-1], x)
+
+    # invalid window
+    with testing.raises(ValueError):
+        contrast_difference(x, x, window=2)
+    with testing.raises(ValueError):
+        contrast_difference(x, x, window=(2,2,2))
+    with testing.raises(ValueError):
+        contrast_difference(x, x, window=(2,3))
+
+    # invalid channels
+    with testing.raises(ValueError):
+        contrast_difference(x, x, multichannel=True)
+
+def test_contrast_difference_grayscale():
+
+    image1 = np.linspace(0, 0.4, 100)
+    image2 = np.linspace(0.4, 0.8, 100)
+    image3 = image1 * 2
+
+    assert_equal(contrast_difference(image1, image2),
+                 np.std(image2)/np.mean(image2)-np.std(image1)/np.mean(image1))
+
+    assert_equal(contrast_difference(image1, image3), 0)
+
+    assert_equal(contrast_difference(image1, image3),
+                 contrast_difference(image1.reshape(10,10),
+                                     image3.reshape((10,10))))
+
+def test_contrast_difference_multichannel():
+
+    N = 10
+    rgb_X = np.random.rand(N, N, N, 3)
+    rgb_Y = np.random.rand(N, N, N, 3)
+
+    rgba_X = np.random.rand(N, N, 4)
+    rgba_Y = np.random.rand(N, N, 4)
+
+    assert_equal(contrast_difference(rgb_X, rgb_Y, multichannel=True),
+                 contrast_difference(rgb2gray(rgb_X), rgb2gray(rgb_Y)))
+
+    assert_equal(contrast_difference(rgba_X, rgba_Y, multichannel=True),
+                 contrast_difference(rgba2rgb(rgba_X), rgba2rgb(rgba_Y),
+                                     multichannel=True))
+
+def test_contrast_difference_windows():
+
+    N = 10
+    X = np.random.rand(N, N)
+    Y = np.random.rand(N, N)
+
+    window = (10, 5)
+
+    contrast_X = (np.std(X[:,:5]) / np.mean(X[:,:5]) +
+                  np.std(X[:,5:]) / np.mean(X[:,5:])) / 2
+
+    contrast_Y = (np.std(Y[:,:5]) / np.mean(Y[:,:5]) +
+                  np.std(Y[:,5:]) / np.mean(Y[:,5:])) / 2
+
+    assert_equal(contrast_difference(X, Y, window=window),
+                 contrast_Y - contrast_X)


### PR DESCRIPTION
## Description
This PR implements a function to measure the contrast difference between two images.
It takes the average of the coefficient of variation (std/mean) of the luminance within each window in an image. 

Implementation based on definition given in this paper:
https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6838039/
which is based on the definition of contrast given in this paper:
https://ieeexplore.ieee.org/document/4623236

Since that top paper is relatively new and not well cited yet, didn't want to push this to the main repo and instead pushing to contrib. Bottom paper is well cited however, and the method makes intuitive sense.

Currently I've constrained it such that the two input images have the same shape, however I'm not sure maybe there's a use case where you'd want to compare 2 differently sized images? In that case however, I'm not too sure how to handle the window sizes, since they have to split the images without requiring padding, but I assume the window sizes should also be the same for both images otherwise the metric would be invalid?

Either way, most of the use cases I can think of would involve equal size images anyway (e.g. comparing image before and after color normalisation) so not sure if this is a huge deal.

This is my first time submitting a PR, so please let me know if there's something I've missed.